### PR TITLE
NotConsumable watermark backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### 1.17.12
+* Backport the `NC` watermark for notConsumed item and fluid stacks - tekcay
+
+### 1.17.11
+* fixed build gradle - tekcay
+
+[...]
+
 ### 1.17.5
 * Port hamering enchant from Tools PR in CEu - BraggestSage833
 * Backport memory leak fix - BraggestSage833

--- a/prism-path.ini
+++ b/prism-path.ini
@@ -1,0 +1,1 @@
+path=/home/pierre/.local/share/PrismLauncher/instances/GTCE-TJ/.minecraft/mods/

--- a/src/main/java/gregtech/GregTechVersion.java
+++ b/src/main/java/gregtech/GregTechVersion.java
@@ -8,7 +8,7 @@ public final class GregTechVersion {
     //This number is incremented every major feature update
     public static final int MINOR = 17;
     //This number is incremented every time the feature is added, or bug is fixed. resets every major version change
-    public static final int REVISION = 11;
+    public static final int REVISION = 12;
     //This number is incremented every build, and never reset. Should always be 0 in the repo code.
     public static final int BUILD = 0;
 

--- a/src/main/java/gregtech/api/fluids/NotConsumedRecipeFluidInput.java
+++ b/src/main/java/gregtech/api/fluids/NotConsumedRecipeFluidInput.java
@@ -1,0 +1,30 @@
+package gregtech.api.fluids;
+
+import gregtech.api.unification.material.type.FluidMaterial;
+import net.minecraftforge.fluids.FluidStack;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+
+public class NotConsumedRecipeFluidInput extends FluidStack {
+
+    private final boolean notConsumed;
+
+    public NotConsumedRecipeFluidInput(FluidStack fluidStack, boolean notConsumed) {
+        super(fluidStack, fluidStack.amount);
+        this.notConsumed = notConsumed;
+    }
+    public NotConsumedRecipeFluidInput(@Nonnull FluidMaterial fluidMaterial, boolean notConsumed) {
+        super(Objects.requireNonNull(fluidMaterial.getMaterialFluid()), 1);
+        this.notConsumed = notConsumed;
+    }
+    public boolean isNotConsumed() {
+        return notConsumed;
+    }
+
+    @Override
+    public NotConsumedRecipeFluidInput copy() {
+        return new NotConsumedRecipeFluidInput(this, this.notConsumed);
+    }
+
+}

--- a/src/main/java/gregtech/api/recipes/Recipe.java
+++ b/src/main/java/gregtech/api/recipes/Recipe.java
@@ -2,6 +2,7 @@ package gregtech.api.recipes;
 
 import com.google.common.collect.ImmutableList;
 import gregtech.api.capability.IMultipleTankHandler;
+import gregtech.api.fluids.NotConsumedRecipeFluidInput;
 import gregtech.api.recipes.recipeproperties.RecipeProperty;
 import gregtech.api.recipes.recipeproperties.RecipePropertyStorage;
 import gregtech.api.util.GTUtility;
@@ -203,12 +204,9 @@ public class Recipe {
         }
 
         for (FluidStack fluid : this.fluidInputs) {
-            int fluidAmount = fluid.amount;
-            boolean isNotConsumed = false;
-            if (fluidAmount == 0) {
-                fluidAmount = 1;
-                isNotConsumed = true;
-            }
+            boolean isNotConsumed = fluid instanceof NotConsumedRecipeFluidInput;
+            int fluidAmount = isNotConsumed ? 0 : fluid.amount;
+
             for (int i = 0; i < fluidInputs.size(); i++) {
                 FluidStack tankFluid = fluidInputs.get(i);
                 if (tankFluid == null || !tankFluid.isFluidEqual(fluid))
@@ -278,9 +276,8 @@ public class Recipe {
         }
         return false;
     }
-
     public List<FluidStack> getFluidOutputs() {
-        return fluidOutputs;
+        return this.fluidOutputs;
     }
 
     public int getDuration() {

--- a/src/main/java/gregtech/api/recipes/RecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/RecipeBuilder.java
@@ -1,9 +1,10 @@
 package gregtech.api.recipes;
 
+import gregtech.api.fluids.NotConsumedRecipeFluidInput;
 import gregtech.api.items.metaitem.MetaItem;
 import gregtech.api.recipes.Recipe.ChanceEntry;
-import gregtech.api.unification.material.type.FluidMaterial;
 import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.unification.material.type.FluidMaterial;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.util.EnumValidationResult;
@@ -184,11 +185,11 @@ public abstract class RecipeBuilder<R extends RecipeBuilder<R>> {
     }
 
     public R notConsumable(FluidMaterial fluidMat) {
-        return fluidInputs(new FluidStack(fluidMat.getFluid(1), 0));
+        return fluidInputs(new NotConsumedRecipeFluidInput(fluidMat, true));
     }
 
     public R notConsumable(FluidStack fluidStack) {
-        return fluidInputs(new FluidStack(fluidStack, 0));
+        return fluidInputs(new NotConsumedRecipeFluidInput(fluidStack, true));
     }
 
     public R output(OrePrefix orePrefix, Material material) {

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -9,6 +9,7 @@ import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.integration.jei.utils.render.ItemStackTextRenderer;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiFluidStackGroup;
@@ -85,8 +86,11 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                 if (handle.getItemHandler() == importItems) {
                     //this is input item stack slot widget, so add it to item group
                     itemStackGroup.init(handle.getSlotIndex(), true,
-                        slotWidget.getPosition().x,
-                        slotWidget.getPosition().y);
+                            new ItemStackTextRenderer(recipeWrapper.isNotConsumedItem(handle.getSlotIndex())),
+                            slotWidget.getPosition().x + 1,
+                            slotWidget.getPosition().y + 1,
+                            slotWidget.getSize().width - 2,
+                            slotWidget.getSize().height - 2, 0, 0);
                 } else if (handle.getItemHandler() == exportItems) {
                     //this is output item stack slot widget, so add it to item group
                     itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false,

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -9,6 +9,7 @@ import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.integration.jei.utils.render.FluidStackTextRenderer;
 import gregtech.integration.jei.utils.render.ItemStackTextRenderer;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
@@ -16,6 +17,7 @@ import mezz.jei.api.gui.IGuiFluidStackGroup;
 import mezz.jei.api.gui.IGuiItemStackGroup;
 import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
+import mezz.jei.api.ingredients.VanillaTypes;
 import mezz.jei.api.recipe.IRecipeCategory;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.fluids.FluidStack;
@@ -23,6 +25,7 @@ import net.minecraftforge.fluids.FluidTank;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.SlotItemHandler;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
@@ -51,28 +54,32 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
         this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3);
     }
 
+    @Nonnull
     @Override
     public String getUid() {
         return GTValues.MODID + ":" + recipeMap.unlocalizedName;
     }
 
+    @Nonnull
     @Override
     public String getTitle() {
         return recipeMap.getLocalizedName();
     }
 
+    @Nonnull
     @Override
     public String getModName() {
         return GTValues.MODID;
     }
 
+    @Nonnull
     @Override
     public IDrawable getBackground() {
         return backgroundDrawable;
     }
 
     @Override
-    public void setRecipe(IRecipeLayout recipeLayout, GTRecipeWrapper recipeWrapper, IIngredients ingredients) {
+    public void setRecipe(IRecipeLayout recipeLayout, @Nonnull GTRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
         IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
         IGuiFluidStackGroup fluidStackGroup = recipeLayout.getFluidStacks();
         for (Widget uiWidget : modularUI.guiWidgets.values()) {
@@ -101,24 +108,29 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                 TankWidget tankWidget = (TankWidget) uiWidget;
                 if (importFluids.getFluidTanks().contains(tankWidget.fluidTank)) {
                     int importIndex = importFluids.getFluidTanks().indexOf(tankWidget.fluidTank);
-                    List<List<FluidStack>> inputsList = ingredients.getInputs(FluidStack.class);
+                    List<List<FluidStack>> inputsList = ingredients.getInputs(VanillaTypes.FLUID);
                     int fluidAmount = 0;
-                    if (inputsList.size() > importIndex && !inputsList.get(importIndex).isEmpty())
+                    if (inputsList.size() > importIndex && !inputsList.get(importIndex).isEmpty()) {
                         fluidAmount = inputsList.get(importIndex).get(0).amount;
+                    }
                     //this is input tank widget, so add it to fluid group
                     fluidStackGroup.init(importIndex, true,
-                        tankWidget.getPosition().x + tankWidget.fluidRenderOffset,
-                        tankWidget.getPosition().y + tankWidget.fluidRenderOffset,
-                        tankWidget.getSize().width - (2 * tankWidget.fluidRenderOffset),
-                        tankWidget.getSize().height - (2 * tankWidget.fluidRenderOffset),
-                        fluidAmount, false, null);
+                            new FluidStackTextRenderer(fluidAmount, false,
+                                    tankWidget.getSize().width - (2 * tankWidget.fluidRenderOffset),
+                                    tankWidget.getSize().height - (2 * tankWidget.fluidRenderOffset), null)
+                                    .setNotConsumed(recipeWrapper.isNotConsumedFluid(importIndex)),
+                            tankWidget.getPosition().x + tankWidget.fluidRenderOffset,
+                            tankWidget.getPosition().y + tankWidget.fluidRenderOffset,
+                            tankWidget.getSize().width - (2 * tankWidget.fluidRenderOffset),
+                            tankWidget.getSize().height - (2 * tankWidget.fluidRenderOffset), 0, 0);
 
                 } else if (exportFluids.getFluidTanks().contains(tankWidget.fluidTank)) {
                     int exportIndex = exportFluids.getFluidTanks().indexOf(tankWidget.fluidTank);
-                    List<List<FluidStack>> inputsList = ingredients.getOutputs(FluidStack.class);
+                    List<List<FluidStack>> inputsList = ingredients.getOutputs(VanillaTypes.FLUID);
                     int fluidAmount = 0;
-                    if (inputsList.size() > exportIndex && !inputsList.get(exportIndex).isEmpty())
+                    if (inputsList.size() > exportIndex && !inputsList.get(exportIndex).isEmpty()) {
                         fluidAmount = inputsList.get(exportIndex).get(0).amount;
+                    }
                     //this is output tank widget, so add it to fluid group
                     fluidStackGroup.init(importFluids.getFluidTanks().size() + exportIndex, false,
                         tankWidget.getPosition().x + tankWidget.fluidRenderOffset,
@@ -137,7 +149,7 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
     }
 
     @Override
-    public void drawExtras(Minecraft minecraft) {
+    public void drawExtras(@Nonnull Minecraft minecraft) {
         for (Widget widget : modularUI.guiWidgets.values()) {
             widget.drawInBackground(0, 0, new IRenderContext() {
             });

--- a/src/main/java/gregtech/integration/jei/utils/render/FluidStackTextRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/FluidStackTextRenderer.java
@@ -1,0 +1,77 @@
+package gregtech.integration.jei.utils.render;
+
+import gregtech.api.gui.resources.RenderUtil;
+import gregtech.api.util.TextFormattingUtil;
+import mezz.jei.api.gui.IDrawable;
+import mezz.jei.plugins.vanilla.ingredients.fluid.FluidStackRenderer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraftforge.fluids.FluidStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class FluidStackTextRenderer extends FluidStackRenderer {
+
+    private boolean notConsumed;
+    private int chanceBase = -1;
+    private int chanceBoost = -1;
+
+    public FluidStackTextRenderer(int capacityMb, boolean showCapacity, int width, int height,
+                                  @Nullable IDrawable overlay) {
+        super(capacityMb, showCapacity, width, height, overlay);
+        this.notConsumed = false;
+    }
+
+    public FluidStackTextRenderer setNotConsumed(boolean notConsumed) {
+        this.notConsumed = notConsumed;
+        return this;
+    }
+
+    @Override
+    public void render(@Nonnull Minecraft minecraft, final int xPosition, final int yPosition,
+                       @Nullable FluidStack fluidStack) {
+        if (fluidStack == null)
+            return;
+
+        GlStateManager.disableBlend();
+
+        RenderUtil.drawFluidForGui(fluidStack, fluidStack.amount, xPosition, yPosition, 17, 17);
+
+        GlStateManager.pushMatrix();
+        GlStateManager.scale(0.5, 0.5, 1);
+
+        String s = TextFormattingUtil.formatLongToCompactString(fluidStack.amount, 4) + "L";
+
+        FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
+        fontRenderer.drawStringWithShadow(s, (xPosition + 6) * 2 - fontRenderer.getStringWidth(s) + 19,
+                (yPosition + 11) * 2, 0xFFFFFF);
+
+        GlStateManager.popMatrix();
+
+        if (this.chanceBase >= 0) {
+            GlStateManager.pushMatrix();
+            GlStateManager.scale(0.5, 0.5, 1);
+            // z hackery to render the text above the item
+            GlStateManager.translate(0, 0, 160);
+
+            String s2 = (this.chanceBase / 100) + "%";
+
+            fontRenderer.drawStringWithShadow(s2, (xPosition + 6) * 2 - fontRenderer.getStringWidth(s2) + 19,
+                    (yPosition + 1) * 2, 0xFFFF00);
+
+            GlStateManager.popMatrix();
+        } else if (notConsumed) {
+            GlStateManager.pushMatrix();
+            GlStateManager.scale(0.5, 0.5, 1);
+
+            fontRenderer.drawStringWithShadow("NC", (xPosition + 6) * 2 - fontRenderer.getStringWidth("NC") + 19,
+                    (yPosition + 1) * 2, 0xFFFF00);
+
+            GlStateManager.popMatrix();
+        }
+
+        GlStateManager.enableBlend();
+    }
+}

--- a/src/main/java/gregtech/integration/jei/utils/render/ItemStackTextRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/ItemStackTextRenderer.java
@@ -1,0 +1,63 @@
+package gregtech.integration.jei.utils.render;
+
+import mezz.jei.plugins.vanilla.ingredients.item.ItemStackRenderer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Taken from the corresponding GTCEU
+ * <a href="https://github.com/GregTechCEu/GregTech/blob/master/src/main/java/gregtech/integration/jei/utils/render/ItemStackTextRenderer.java">
+ * ItemStackTextRenderer.java</a> class.
+ */
+public class ItemStackTextRenderer extends ItemStackRenderer {
+
+    private final int chanceBase;
+    private final int chanceBoost;
+    private final boolean notConsumed;
+
+    public ItemStackTextRenderer(boolean notConsumed) {
+        this.chanceBase = -1;
+        this.chanceBoost = -1;
+        this.notConsumed = notConsumed;
+    }
+
+    @Override
+    public void render(@Nonnull Minecraft minecraft, int xPosition, int yPosition, @Nullable ItemStack ingredient) {
+        super.render(minecraft, xPosition, yPosition, ingredient);
+
+        if (this.chanceBase >= 0) {
+            GlStateManager.disableBlend();
+            GlStateManager.pushMatrix();
+            GlStateManager.scale(0.5, 0.5, 1);
+            // z hackery to render the text above the item
+            GlStateManager.translate(0, 0, 160);
+
+            String s = (this.chanceBase / 100) + "%";
+
+            FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
+            fontRenderer.drawStringWithShadow(s, (xPosition + 6) * 2 - fontRenderer.getStringWidth(s) + 19,
+                    (yPosition + 1) * 2, 0xFFFF00);
+
+            GlStateManager.popMatrix();
+            GlStateManager.enableBlend();
+        } else if (this.notConsumed) {
+            GlStateManager.disableBlend();
+            GlStateManager.pushMatrix();
+            GlStateManager.scale(0.5, 0.5, 1);
+            // z hackery to render the text above the item
+            GlStateManager.translate(0, 0, 160);
+
+            FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
+            fontRenderer.drawStringWithShadow("NC", (xPosition + 6) * 2 - fontRenderer.getStringWidth("NC") + 19,
+                    (yPosition + 1) * 2, 0xFFFF00);
+
+            GlStateManager.popMatrix();
+            GlStateManager.enableBlend();
+        }
+    }
+}


### PR DESCRIPTION
**What:**
Backports the `NC` watermark used in GTCEu dislayed in JEI in the case of not consumed `ItemStack` or `FluidStack`.

**How solved:**
Basically copied and tweaked a little bit GTCEu [ItemStackTextRenderer](https://github.com/GregTechCEu/GregTech/blob/master/src/main/java/gregtech/integration/jei/utils/render/ItemStackTextRenderer.java),  [FluidStackTextRenderer](https://github.com/GregTechCEu/GregTech/blob/master/src/main/java/gregtech/integration/jei/utils/render/FluidStackTextRenderer.java) classes.

**Outcome:**
![watermark](https://github.com/tekcay/GTCE-TJ-Fork/assets/39018013/fde8f0a2-0097-429f-ba92-8801beb3622d)
